### PR TITLE
fix(runtime): spill oversized MCP/tool results to artifact store before truncation

### DIFF
--- a/crates/librefang-runtime/src/agent_loop.rs
+++ b/crates/librefang-runtime/src/agent_loop.rs
@@ -1309,6 +1309,31 @@ async fn execute_single_tool_call_inner(
         result.content.clone()
     };
 
+    // Spill the full raw result to the artifact store BEFORE
+    // `sanitize_tool_result_content` truncates it. Web tools spill at
+    // execution time, but MCP (and any other) results arrive un-spilled, so
+    // without this they would be destructively truncated and the original
+    // bytes lost — the LLM would get clipped text with no `read_artifact`
+    // reference. A web stub is already < threshold, so this is a no-op pass
+    // through for it (no double-spill).
+    let result_content = {
+        let cfg = ctx.opts.tool_results_config.clone().unwrap_or_default();
+        let (threshold, max_artifact) = crate::tool_runner::resolve_spill_config(
+            cfg.spill_threshold_bytes,
+            cfg.max_artifact_bytes,
+        );
+        match crate::artifact_store::maybe_spill(
+            &tool_call.name,
+            result_content.as_bytes(),
+            threshold,
+            max_artifact,
+            &crate::artifact_store::default_artifact_storage_dir(),
+        ) {
+            Some(stub) => stub,
+            None => result_content,
+        }
+    };
+
     let content = sanitize_tool_result_content(
         &result_content,
         ctx.context_budget,
@@ -13848,6 +13873,123 @@ mod tests {
             "in-memory session must still contain user msg + assistant reply (only the \
              SQLite write is suppressed) — got {} msgs",
             session.messages.len(),
+        );
+    }
+
+    // ── tool-result artifact spill happens BEFORE destructive truncation ──
+    //
+    // Pins the ordering in `execute_single_tool_call_inner`: oversized tool
+    // results (notably MCP, which does not spill at execution time the way
+    // web_fetch/web_search do) must be written to the artifact store on the
+    // full raw bytes BEFORE `sanitize_tool_result_content` truncates. The
+    // contrast assertion documents the bug this prevents — sanitizing the raw
+    // result first silently truncates it and drops the `read_artifact`
+    // reference, losing the original bytes.
+
+    fn extract_artifact_handle(stub: &str) -> &str {
+        let start = stub
+            .find("read_artifact(\"")
+            .expect("stub must contain a read_artifact(\"…\") reference")
+            + "read_artifact(\"".len();
+        let rest = &stub[start..];
+        let end = rest.find('"').expect("unterminated handle in stub");
+        &rest[..end]
+    }
+
+    #[test]
+    fn oversized_tool_result_spills_before_sanitize_preserves_full_bytes() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let threshold: u64 = 16_384; // ToolResultsConfig::default().spill_threshold_bytes
+        let max_artifact = crate::artifact_store::DEFAULT_MAX_ARTIFACT_BYTES;
+
+        // 54_000 bytes of plain text: over the 16 KiB spill threshold and
+        // over the per-result truncation cap (0.6 * 20_000-token window =
+        // 12_000 chars), but under artifact_store::MAX_READ_LENGTH (64 KiB)
+        // so a single `read` call verifies the full payload was preserved.
+        let raw = "lorem ipsum dolor sit amet ".repeat(2_000);
+
+        // Step 1 (the fix): spill the FULL raw bytes first.
+        let stub = crate::artifact_store::maybe_spill(
+            "mcp_some_server.some_tool",
+            raw.as_bytes(),
+            threshold,
+            max_artifact,
+            dir.path(),
+        )
+        .expect("oversized result must spill to an artifact stub");
+        assert!(
+            stub.contains("sha256:") && stub.contains("read_artifact(\""),
+            "stub must carry a retrievable artifact reference, got: {stub}"
+        );
+        assert!(
+            stub.len() < raw.len(),
+            "stub must be compact relative to the original"
+        );
+
+        // Step 2: sanitize runs on the small stub. It may further compact the
+        // inline preview (strip_tool_result_details), but the crucial
+        // read_artifact recovery reference and handle must survive intact so
+        // the LLM can still fetch the full content.
+        let handle = extract_artifact_handle(&stub).to_string();
+        let budget = ContextBudget::new(20_000);
+        let after = sanitize_tool_result_content(&stub, &budget, None, 20_000);
+        assert!(
+            after.contains("read_artifact(\"") && after.contains(&handle),
+            "sanitize must preserve the read_artifact recovery reference on \
+             the spilled stub, got: {after}"
+        );
+        assert!(
+            after.len() < raw.len(),
+            "the post-spill result stays compact relative to the original"
+        );
+
+        // The full original bytes are retrievable from the artifact store.
+        let fetched = crate::artifact_store::read(&handle, 0, raw.len(), dir.path())
+            .expect("artifact must be readable");
+        assert_eq!(
+            fetched,
+            raw.as_bytes(),
+            "artifact must preserve the full original result, untruncated"
+        );
+
+        // Contrast — the OLD (buggy) order: sanitize the raw result first.
+        // It is destructively truncated and carries no artifact reference,
+        // i.e. the original bytes would be permanently lost.
+        let truncated_first = sanitize_tool_result_content(&raw, &budget, None, 20_000);
+        assert!(
+            truncated_first.len() < raw.len() && !truncated_first.contains("read_artifact("),
+            "sanitizing raw content first loses data with no recovery handle — \
+             this is exactly what spilling-before-sanitize prevents"
+        );
+    }
+
+    #[test]
+    fn small_or_already_spilled_result_passes_through_without_double_spill() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let threshold: u64 = 16_384;
+        let max_artifact = crate::artifact_store::DEFAULT_MAX_ARTIFACT_BYTES;
+
+        // A web tool already produced a compact stub at execution time. It is
+        // far below the spill threshold, so the chokepoint spill is a no-op
+        // pass-through (`None`) — no second artifact, no nested stub.
+        let web_stub = "[tool_result: web_fetch | sha256:".to_string()
+            + &"0".repeat(64)
+            + " | 1048576 bytes | preview:]\nsome page text\n-- truncated. \
+               Use read_artifact(\"sha256:"
+            + &"0".repeat(64)
+            + "\", offset, length) to fetch the rest.";
+        assert!(web_stub.len() < threshold as usize);
+
+        let spilled = crate::artifact_store::maybe_spill(
+            "web_fetch",
+            web_stub.as_bytes(),
+            threshold,
+            max_artifact,
+            dir.path(),
+        );
+        assert!(
+            spilled.is_none(),
+            "an already-compact web stub must NOT be re-spilled (no double-spill)"
         );
     }
 }

--- a/crates/librefang-runtime/src/tool_runner.rs
+++ b/crates/librefang-runtime/src/tool_runner.rs
@@ -3971,7 +3971,10 @@ async fn tool_apply_patch(
 /// Resolve `[tool_results]` spill threshold + per-artifact cap from raw
 /// `ToolExecContext` fields, falling back to compiled defaults when the
 /// caller passed `0` (test call sites that don't populate the ctx).
-fn resolve_spill_config(spill_threshold_bytes: u64, max_artifact_bytes: u64) -> (u64, u64) {
+pub(crate) fn resolve_spill_config(
+    spill_threshold_bytes: u64,
+    max_artifact_bytes: u64,
+) -> (u64, u64) {
     (
         if spill_threshold_bytes == 0 {
             16_384 // ToolResultsConfig::default().spill_threshold_bytes


### PR DESCRIPTION
MCP tool results were returned raw with no artifact spill, unlike web_fetch
/web_search which spill at execution time. The shared chokepoint
execute_single_tool_call_inner ran sanitize_tool_result_content (destructive
truncation) BEFORE ToolBudgetEnforcer::maybe_persist_result, so a large MCP
result was truncated first; the truncated text was then under the 16 KiB
spill threshold and no artifact was created. The LLM received clipped output
with no read_artifact(...) recovery reference and the original bytes were
lost.

Spill the full raw result to the artifact store inside the shared chokepoint
BEFORE sanitize/truncation, uniformly for all tools (MCP included), covering
both the streaming and non-streaming loops. Already-compact web stubs are
below the threshold so maybe_spill is a no-op pass-through (no double-spill).
The later Layer-3 per-turn enforcer is unchanged and remains a harmless
aggregate safety net.

- resolve_spill_config made pub(crate) for reuse (no duplicated constants)
- Added two ordering-invariant tests in the runtime crate test module

Verification: cargo check -p librefang-runtime; clippy -p librefang-runtime
--all-targets -D warnings (clean); cargo test -p librefang-runtime (1710 lib
+ all integration tests pass). Workspace-wide check is blocked by a
pre-existing unrelated toolchain pin (sysinfo@0.39.1 needs rustc 1.95); CI
builds the full workspace on a supported toolchain.